### PR TITLE
Create FloatChat Flutter prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+pubspec.lock
+build/
+android/
+ios/
+web/
+linux/
+macos/
+windows/
+coverage/
+*.iml
+.idea/
+*.log

--- a/assets/dolphin_mascot.txt
+++ b/assets/dolphin_mascot.txt
@@ -1,0 +1,1 @@
+This placeholder represents the FloatChat dolphin mascot asset. 🐬

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'pages/analysis_page.dart';
+import 'pages/chat_page.dart';
+import 'pages/settings_page.dart';
+import 'widgets/profile_selector.dart';
+
+void main() {
+  runApp(const FloatChatApp());
+}
+
+class FloatChatApp extends StatefulWidget {
+  const FloatChatApp({super.key});
+
+  @override
+  State<FloatChatApp> createState() => _FloatChatAppState();
+}
+
+class _FloatChatAppState extends State<FloatChatApp> {
+  int _currentIndex = 1; // Chat is the initial page
+  ThemeMode _themeMode = ThemeMode.light;
+  final ValueNotifier<ProfileMode> _profileNotifier =
+      ValueNotifier<ProfileMode>(ProfileMode.general);
+
+  @override
+  void dispose() {
+    _profileNotifier.dispose();
+    super.dispose();
+  }
+
+  void _onThemeChanged(bool isDark) {
+    setState(() {
+      _themeMode = isDark ? ThemeMode.dark : ThemeMode.light;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<ProfileMode>(
+      valueListenable: _profileNotifier,
+      builder: (context, profileMode, _) {
+        return MaterialApp(
+          title: 'FloatChat',
+          debugShowCheckedModeBanner: false,
+          themeMode: _themeMode,
+          theme: ThemeData(
+            colorSchemeSeed: const Color(0xFF0A8BD9),
+            brightness: Brightness.light,
+            textTheme: GoogleFonts.interTextTheme(),
+            useMaterial3: true,
+          ),
+          darkTheme: ThemeData(
+            colorSchemeSeed: const Color(0xFF0A8BD9),
+            brightness: Brightness.dark,
+            textTheme: GoogleFonts.interTextTheme(ThemeData.dark().textTheme),
+            useMaterial3: true,
+          ),
+          home: Scaffold(
+            appBar: FloatChatAppBar(
+              profileMode: profileMode,
+              onTap: () => showProfileSelector(context, _profileNotifier),
+            ),
+            body: IndexedStack(
+              index: _currentIndex,
+              children: [
+                AnalysisPage(profileNotifier: _profileNotifier),
+                ChatPage(profileNotifier: _profileNotifier),
+                SettingsPage(
+                  onThemeChanged: _onThemeChanged,
+                  isDarkMode: _themeMode == ThemeMode.dark,
+                ),
+              ],
+            ),
+            bottomNavigationBar: NavigationBar(
+              selectedIndex: _currentIndex,
+              onDestinationSelected: (index) {
+                setState(() => _currentIndex = index);
+              },
+              destinations: const [
+                NavigationDestination(
+                  icon: Icon(Icons.public),
+                  label: 'Analysis',
+                ),
+                NavigationDestination(
+                  icon: Icon(Icons.chat_bubble_outline),
+                  label: 'Chat',
+                ),
+                NavigationDestination(
+                  icon: Icon(Icons.settings_outlined),
+                  label: 'Settings',
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class FloatChatAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const FloatChatAppBar({
+    super.key,
+    required this.profileMode,
+    required this.onTap,
+  });
+
+  final ProfileMode profileMode;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      titleSpacing: 0,
+      title: Row(
+        children: [
+          const SizedBox(width: 16),
+          CircleAvatar(
+            radius: 18,
+            backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+            child: const Text('🐬', style: TextStyle(fontSize: 20)),
+          ),
+          const SizedBox(width: 12),
+          Text(
+            'FloatChat',
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+        ],
+      ),
+      actions: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: ProfileSelectorChip(
+            profileMode: profileMode,
+            onPressed: onTap,
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/pages/analysis_page.dart
+++ b/lib/pages/analysis_page.dart
@@ -1,0 +1,480 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../widgets/profile_selector.dart';
+
+class FloatMarkerData {
+  const FloatMarkerData({
+    required this.id,
+    required this.position,
+    required this.latestTemperature,
+    required this.depthHighlight,
+    required this.salinity,
+    required this.oxygen,
+  });
+
+  final String id;
+  final LatLng position;
+  final double latestTemperature;
+  final double depthHighlight;
+  final double salinity;
+  final double oxygen;
+}
+
+class AnalysisPage extends StatefulWidget {
+  const AnalysisPage({super.key, this.profileNotifier});
+
+  final ValueNotifier<ProfileMode>? profileNotifier;
+
+  @override
+  State<AnalysisPage> createState() => _AnalysisPageState();
+}
+
+class _AnalysisPageState extends State<AnalysisPage> {
+  final MapController _mapController = MapController();
+
+  final List<FloatMarkerData> _markers = const [
+    FloatMarkerData(
+      id: 'IN-9023',
+      position: LatLng(15.5, 73.8),
+      latestTemperature: 28.4,
+      depthHighlight: 120,
+      salinity: 34.8,
+      oxygen: 5.6,
+    ),
+    FloatMarkerData(
+      id: 'IN-1775',
+      position: LatLng(9.9, 76.2),
+      latestTemperature: 27.1,
+      depthHighlight: 140,
+      salinity: 35.2,
+      oxygen: 6.1,
+    ),
+    FloatMarkerData(
+      id: 'IN-4410',
+      position: LatLng(18.1, 72.9),
+      latestTemperature: 29.2,
+      depthHighlight: 95,
+      salinity: 34.5,
+      oxygen: 5.2,
+    ),
+  ];
+
+  void _openFloatDetails(FloatMarkerData data) {
+    final profileMode = widget.profileNotifier?.value ?? ProfileMode.general;
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) {
+        return DraggableScrollableSheet(
+          expand: false,
+          builder: (context, controller) {
+            return SingleChildScrollView(
+              controller: controller,
+              padding: const EdgeInsets.fromLTRB(24, 0, 24, 32),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      CircleAvatar(
+                        radius: 24,
+                        child: const Text('🐬', style: TextStyle(fontSize: 28)),
+                      ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Float ${data.id}',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .titleLarge
+                                  ?.copyWith(fontWeight: FontWeight.bold),
+                            ),
+                            Text('Last profile: ${data.latestTemperature.toStringAsFixed(1)}°C at ${data.depthHighlight.toStringAsFixed(0)} m'),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    children: [
+                      _MetricCard(
+                        title: 'Temperature',
+                        value: '${data.latestTemperature.toStringAsFixed(1)} °C',
+                        subtitle: 'Surface anomaly +0.8°C',
+                        icon: Icons.thermostat,
+                      ),
+                      _MetricCard(
+                        title: 'Salinity',
+                        value: '${data.salinity.toStringAsFixed(1)} PSU',
+                        subtitle: 'Halocline shift 12 m',
+                        icon: Icons.water_drop_outlined,
+                      ),
+                      _MetricCard(
+                        title: 'Oxygen',
+                        value: '${data.oxygen.toStringAsFixed(1)} ml/l',
+                        subtitle: 'Hypoxia risk low',
+                        icon: Icons.bubble_chart_outlined,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  _InsightBanner(profileMode: profileMode),
+                  const SizedBox(height: 24),
+                  Text(
+                    'Profiles in dashboard',
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 12),
+                  const _ProfilesDescription(),
+                  const SizedBox(height: 24),
+                  _DownloadRow(floatId: data.id),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        FlutterMap(
+          mapController: _mapController,
+          options: MapOptions(
+            initialCenter: const LatLng(15.0, 78.0),
+            initialZoom: 4.8,
+            interactionOptions: const InteractionOptions(
+              flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
+            ),
+          ),
+          children: [
+            TileLayer(
+              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              userAgentPackageName: 'com.example.floatchat',
+            ),
+            MarkerLayer(
+              markers: _markers
+                  .map(
+                    (marker) => Marker(
+                      point: marker.position,
+                      width: 80,
+                      height: 80,
+                      child: GestureDetector(
+                        onTap: () => _openFloatDetails(marker),
+                        child: AnimatedContainer(
+                          duration: const Duration(milliseconds: 300),
+                          curve: Curves.easeInOut,
+                          padding: const EdgeInsets.all(8),
+                          decoration: BoxDecoration(
+                            color: Colors.lightBlueAccent.withOpacity(0.85),
+                            borderRadius: BorderRadius.circular(18),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withOpacity(0.15),
+                                blurRadius: 10,
+                                offset: const Offset(0, 6),
+                              ),
+                            ],
+                          ),
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              const Text('🐬', style: TextStyle(fontSize: 20)),
+                              Text(
+                                marker.id,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+        ),
+        Positioned(
+          right: 16,
+          top: 16,
+          child: ElevatedButton.icon(
+            onPressed: () {
+              showModalBottomSheet(
+                context: context,
+                showDragHandle: true,
+                builder: (_) => Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: const [
+                      Text(
+                        'Export queued',
+                        style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                      ),
+                      SizedBox(height: 12),
+                      Text(
+                        'A CSV export with the latest temperature, salinity, and oxygen profiles will be available in your downloads shortly. 🐬',
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+            icon: const Icon(Icons.download_outlined),
+            label: const Text('Export CSV'),
+            style: ElevatedButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+            ),
+          ),
+        ),
+        Positioned(
+          left: 16,
+          bottom: 16,
+          right: 16,
+          child: _RealtimeInsightPanel(markers: _markers),
+        ),
+      ],
+    );
+  }
+}
+
+class _MetricCard extends StatelessWidget {
+  const _MetricCard({
+    required this.title,
+    required this.value,
+    required this.subtitle,
+    required this.icon,
+  });
+
+  final String title;
+  final String value;
+  final String subtitle;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: 170,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.6),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: theme.colorScheme.primary),
+          const SizedBox(height: 12),
+          Text(title, style: theme.textTheme.titleSmall),
+          const SizedBox(height: 8),
+          Text(
+            value,
+            style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 6),
+          Text(subtitle, style: theme.textTheme.bodySmall),
+        ],
+      ),
+    );
+  }
+}
+
+class _InsightBanner extends StatelessWidget {
+  const _InsightBanner({required this.profileMode});
+
+  final ProfileMode profileMode;
+
+  @override
+  Widget build(BuildContext context) {
+    final tone = switch (profileMode) {
+      ProfileMode.agency =>
+          'Policy insight: surface warming exceeds treaty targets near EEZ corridors. Della suggests reviewing adaptive shipping advisories.',
+      ProfileMode.researcher =>
+          'Research insight: salinity drop coincides with freshwater plume on 12 June. Consider overlaying cyclone Biparjoy tracks.',
+      ProfileMode.educator =>
+          'Teaching tip: compare pre- and post-monsoon profiles to explain thermal layering to students.',
+      ProfileMode.general =>
+          'Ocean note: it\'s a great time to watch how currents carry warm water along India\'s coasts.',
+    };
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Row(
+        children: [
+          const Text('🐬', style: TextStyle(fontSize: 28)),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              tone,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: Theme.of(context).colorScheme.onPrimaryContainer),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfilesDescription extends StatelessWidget {
+  const _ProfilesDescription();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Profile Plots',
+          style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          'Y-axis: Depth (0–2000 m). X-axis: Temperature / Salinity / Oxygen etc. Shows how the ocean changes with depth.',
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Time Series of Profiles',
+          style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          'Profiles collected over time → compare January vs June at the same location.',
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Profile Map Integration',
+          style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          'Each float’s location on map → click → see its latest profile. Profiles = the core data product of ARGO.',
+        ),
+        const SizedBox(height: 12),
+        const Text(
+          'Use the dashboard to select a float, view the latest profile, overlay multiple profiles (e.g., before & after a cyclone), download in CSV/NetCDF, and spot anomalies like “surface warming > 1°C compared to baseline.”',
+        ),
+      ],
+    );
+  }
+}
+
+class _DownloadRow extends StatelessWidget {
+  const _DownloadRow({required this.floatId});
+
+  final String floatId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ElevatedButton.icon(
+          onPressed: () {},
+          icon: const Icon(Icons.stacked_line_chart),
+          label: const Text('Overlay profiles'),
+        ),
+        const SizedBox(height: 12),
+        ElevatedButton.icon(
+          onPressed: () {},
+          icon: const Icon(Icons.analytics_outlined),
+          label: Text('View anomalies for $floatId'),
+        ),
+        const SizedBox(height: 12),
+        OutlinedButton.icon(
+          onPressed: () {},
+          icon: const Icon(Icons.download_for_offline_outlined),
+          label: const Text('Download NetCDF'),
+        ),
+      ],
+    );
+  }
+}
+
+class _RealtimeInsightPanel extends StatelessWidget {
+  const _RealtimeInsightPanel({required this.markers});
+
+  final List<FloatMarkerData> markers;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface.withOpacity(0.9),
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.08),
+            blurRadius: 18,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                const Text('🐬', style: TextStyle(fontSize: 24)),
+                const SizedBox(width: 12),
+                Text(
+                  'Real-time AI Insights',
+                  style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            ...markers.map(
+              (marker) => Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    const Icon(Icons.radar, size: 18),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'Float ${marker.id}: Surface temp ${marker.latestTemperature.toStringAsFixed(1)}°C, anomaly +${(marker.latestTemperature - 27).toStringAsFixed(1)}°C. Oxygen ${marker.oxygen.toStringAsFixed(1)} ml/l.',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -1,0 +1,249 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../widgets/profile_selector.dart';
+
+class ChatMessage {
+  ChatMessage({
+    required this.text,
+    required this.isUser,
+  });
+
+  final String text;
+  final bool isUser;
+}
+
+class ChatPage extends StatefulWidget {
+  const ChatPage({super.key, this.profileNotifier});
+
+  final ValueNotifier<ProfileMode>? profileNotifier;
+
+  @override
+  State<ChatPage> createState() => _ChatPageState();
+}
+
+class _ChatPageState extends State<ChatPage> {
+  final TextEditingController _controller = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  final List<ChatMessage> _messages = [
+    ChatMessage(
+      text:
+          '🐬 Hello! I\'m Della the FloatChat dolphin. Ask me about any ARGO float and I\'ll surface insights with maps, graphs, and context.',
+      isUser: false,
+    ),
+  ];
+  bool _isGenerating = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _sendMessage() {
+    final trimmed = _controller.text.trim();
+    if (trimmed.isEmpty || _isGenerating) return;
+
+    setState(() {
+      _messages.add(ChatMessage(text: trimmed, isUser: true));
+      _isGenerating = true;
+      _controller.clear();
+    });
+
+    _scrollToBottom();
+
+    Timer(const Duration(milliseconds: 1800), () {
+      if (!mounted) return;
+      final profile = widget.profileNotifier?.value ?? ProfileMode.general;
+      setState(() {
+        _messages.add(ChatMessage(
+          isUser: false,
+          text: _mockResponse(profile, trimmed),
+        ));
+        _isGenerating = false;
+      });
+      _scrollToBottom();
+    });
+  }
+
+  String _mockResponse(ProfileMode profile, String query) {
+    final baseIntro = switch (profile) {
+      ProfileMode.agency =>
+          'For policy review: wave height anomalies near Bay of Bengal show +1.2m versus baseline.',
+      ProfileMode.researcher =>
+          'Research brief: Float 290313 analyzed. Thermocline dipped 35m post-monsoon burst.',
+      ProfileMode.educator =>
+          'Classroom snapshot: notice how warm surface water layers mix during summer monsoon.',
+      ProfileMode.general =>
+          'Ocean insight: surface temps are trending warmer around the Indian peninsula.',
+    };
+
+    return '$baseIntro\n\nBased on your prompt "$query", I\'ve staged depth vs temperature and salinity charts plus an oxygen anomaly timeline. Tap the Analysis tab to compare floats, overlay cyclonic events, or export NetCDF snapshots. 🐬';
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_scrollController.hasClients) return;
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent + 80,
+        duration: const Duration(milliseconds: 350),
+        curve: Curves.easeOut,
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.separated(
+            controller: _scrollController,
+            padding: const EdgeInsets.all(20),
+            itemCount: _messages.length + (_isGenerating ? 1 : 0),
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemBuilder: (context, index) {
+              if (_isGenerating && index == _messages.length) {
+                return Align(
+                  alignment: Alignment.centerLeft,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceVariant.withOpacity(0.6),
+                      borderRadius: BorderRadius.circular(18),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: const [
+                        SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2.5),
+                        ),
+                        SizedBox(width: 12),
+                        Text('Della is crafting insights...'),
+                      ],
+                    ),
+                  ),
+                );
+              }
+
+              final message = _messages[index];
+              final alignment =
+                  message.isUser ? Alignment.centerRight : Alignment.centerLeft;
+              final bubbleColor = message.isUser
+                  ? theme.colorScheme.primaryContainer
+                  : theme.colorScheme.surfaceVariant.withOpacity(0.6);
+              final textColor = message.isUser
+                  ? theme.colorScheme.onPrimaryContainer
+                  : theme.colorScheme.onSurfaceVariant;
+              return Align(
+                alignment: alignment,
+                child: Container(
+                  constraints: const BoxConstraints(maxWidth: 320),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+                  decoration: BoxDecoration(
+                    color: bubbleColor,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Text(
+                    message.text,
+                    style: theme.textTheme.bodyMedium?.copyWith(color: textColor),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        SafeArea(
+          top: false,
+          minimum: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+          child: _buildInputBar(context),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildInputBar(BuildContext context) {
+    final theme = Theme.of(context);
+    final selectedMode = widget.profileNotifier?.value ?? ProfileMode.general;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(28),
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.4),
+      ),
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.add_circle_outline),
+            tooltip: 'Upload files for analysis',
+            onPressed: () {
+              showModalBottomSheet(
+                context: context,
+                showDragHandle: true,
+                builder: (context) {
+                  return Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: const [
+                        Text(
+                          'Upload Data',
+                          style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                        ),
+                        SizedBox(height: 12),
+                        Text(
+                          'Attach NetCDF, CSV, or imagery files to enrich the upcoming analysis. The preview and parsing will appear in chat. 🐬',
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+          Expanded(
+            child: TextField(
+              controller: _controller,
+              minLines: 1,
+              maxLines: 4,
+              decoration: const InputDecoration(
+                hintText: 'Ask Della to explore ARGO floats, trends, or anomalies...',
+                border: InputBorder.none,
+              ),
+              onSubmitted: (_) => _sendMessage(),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: ProfileSelectorChip(
+              profileMode: selectedMode,
+              onPressed: () {
+                final notifier = widget.profileNotifier;
+                if (notifier != null) {
+                  showProfileSelector(context, notifier);
+                }
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: FilledButton.tonal(
+              onPressed: _isGenerating ? null : _sendMessage,
+              style: FilledButton.styleFrom(
+                shape: const CircleBorder(),
+                padding: const EdgeInsets.all(18),
+              ),
+              child: const Icon(Icons.send_rounded),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key, this.onThemeChanged, this.isDarkMode = false});
+
+  final ValueChanged<bool>? onThemeChanged;
+  final bool isDarkMode;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(20),
+      children: [
+        _SettingsSection(
+          title: 'Preferences',
+          children: [
+            SwitchListTile(
+              title: const Text('Dark theme'),
+              subtitle: const Text('Toggle to rest your eyes during late-night dives.'),
+              value: isDarkMode,
+              onChanged: onThemeChanged,
+              secondary: const Icon(Icons.nightlight_round),
+            ),
+            SwitchListTile(
+              title: const Text('Enable notifications'),
+              subtitle: const Text('Get pinged when Della detects new anomalies.'),
+              value: true,
+              onChanged: (_) {},
+              secondary: const Icon(Icons.notifications_active_outlined),
+            ),
+            SwitchListTile(
+              title: const Text('Ocean health digests'),
+              subtitle: const Text('Weekly digest of top floats and regions to watch.'),
+              value: true,
+              onChanged: (_) {},
+              secondary: const Icon(Icons.podcasts_outlined),
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        _SettingsSection(
+          title: 'Storage & privacy',
+          children: [
+            ListTile(
+              leading: const Icon(Icons.cleaning_services_outlined),
+              title: const Text('Clear cache'),
+              subtitle: const Text('Remove downloaded ARGO profiles and previews.'),
+              trailing: FilledButton(
+                onPressed: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Cache cleared. Della thanks you! 🐬')),
+                  );
+                },
+                child: const Text('Clear'),
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.lock_outline),
+              title: const Text('Privacy controls'),
+              subtitle: const Text('Manage how shared data contributes to community insights.'),
+              onTap: () {},
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        _SettingsSection(
+          title: 'Account',
+          children: [
+            ListTile(
+              leading: const Icon(Icons.person_outline),
+              title: const Text('Profile & identity'),
+              subtitle: const Text('Adjust your ocean role, avatar, and affiliations.'),
+              onTap: () {},
+            ),
+            ListTile(
+              leading: const Icon(Icons.logout),
+              title: const Text('Logout'),
+              subtitle: const Text('Surface for air and sign back in later.'),
+              onTap: () {},
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _SettingsSection extends StatelessWidget {
+  const _SettingsSection({required this.title, required this.children});
+
+  final String title;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 12),
+        ...children.map(
+          (child) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceVariant.withOpacity(0.35),
+                borderRadius: BorderRadius.circular(18),
+              ),
+              child: child,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/profile_selector.dart
+++ b/lib/widgets/profile_selector.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+enum ProfileMode {
+  agency,
+  researcher,
+  educator,
+  general,
+}
+
+extension ProfileModeX on ProfileMode {
+  String get label {
+    switch (this) {
+      case ProfileMode.agency:
+        return 'Agency Mode';
+      case ProfileMode.researcher:
+        return 'Researcher Mode';
+      case ProfileMode.educator:
+        return 'Educator Mode';
+      case ProfileMode.general:
+        return 'General Model';
+    }
+  }
+
+  String get description {
+    switch (this) {
+      case ProfileMode.agency:
+        return 'Policy-ready intelligence for agencies & policymakers.';
+      case ProfileMode.researcher:
+        return 'Data-deep dives with scientific context for researchers.';
+      case ProfileMode.educator:
+        return 'Classroom-friendly explanations for educators & students.';
+      case ProfileMode.general:
+        return 'Conversational ocean insights for everyone.';
+    }
+  }
+
+  IconData get icon {
+    switch (this) {
+      case ProfileMode.agency:
+        return Icons.account_balance;
+      case ProfileMode.researcher:
+        return Icons.science_outlined;
+      case ProfileMode.educator:
+        return Icons.menu_book_outlined;
+      case ProfileMode.general:
+        return Icons.emoji_people_outlined;
+    }
+  }
+}
+
+class ProfileSelectorChip extends StatelessWidget {
+  const ProfileSelectorChip({
+    super.key,
+    required this.profileMode,
+    required this.onPressed,
+  });
+
+  final ProfileMode profileMode;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return ActionChip(
+      avatar: Icon(profileMode.icon, size: 20),
+      label: Text(profileMode.label),
+      onPressed: onPressed,
+      shape: StadiumBorder(
+        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      backgroundColor: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.3),
+    );
+  }
+}
+
+Future<void> showProfileSelector(
+  BuildContext context,
+  ValueNotifier<ProfileMode> profileNotifier,
+) async {
+  final theme = Theme.of(context);
+  await showModalBottomSheet(
+    context: context,
+    showDragHandle: true,
+    builder: (context) {
+      return ValueListenableBuilder<ProfileMode>(
+        valueListenable: profileNotifier,
+        builder: (context, selectedMode, _) {
+          return ListView.separated(
+            padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
+            itemCount: ProfileMode.values.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemBuilder: (context, index) {
+              final mode = ProfileMode.values[index];
+              final isSelected = mode == selectedMode;
+              return ListTile(
+                leading: CircleAvatar(
+                  child: Icon(mode.icon),
+                ),
+                title: Text(mode.label, style: theme.textTheme.titleMedium),
+                subtitle: Text(mode.description),
+                trailing: isSelected
+                    ? Icon(Icons.check_circle, color: theme.colorScheme.primary)
+                    : null,
+                onTap: () {
+                  profileNotifier.value = mode;
+                  Navigator.of(context).pop();
+                },
+              );
+            },
+          );
+        },
+      );
+    },
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,20 @@
+name: floatchat
+description: A prototype AI-assisted ocean analysis chat application.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  flutter_map: ^6.0.0
+  latlong2: ^0.9.1
+  google_fonts: ^6.1.0
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/


### PR DESCRIPTION
## Summary
- scaffold a Flutter prototype app with shared FloatChat app bar and bottom navigation between Analysis, Chat, and Settings views
- implement chat experience with dolphin mascot assistant, profile selector modal, upload sheet, and simulated response streaming
- add analysis dashboard using Flutter Map with interactive markers near India, rich float detail sheets, export modal, and realtime insight panel
- create modern settings page featuring theme toggle, notification preferences, cache clearing feedback, and account actions

## Testing
- Not run (Flutter SDK not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68d199069d488332a11b357f59fc48d3