### PR TITLE
Enhance FloatChat map insights and chat charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+pubspec.lock
+build/
+android/
+ios/
+web/
+linux/
+macos/
+windows/
+coverage/
+*.iml
+.idea/
+*.log

--- a/assets/dolphin_mascot.txt
+++ b/assets/dolphin_mascot.txt
@@ -1,0 +1,1 @@
+This placeholder represents the FloatChat dolphin mascot asset. 🐬

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'pages/analysis_page.dart';
+import 'pages/chat_page.dart';
+import 'pages/settings_page.dart';
+import 'widgets/profile_selector.dart';
+
+void main() {
+  runApp(const FloatChatApp());
+}
+
+class FloatChatApp extends StatefulWidget {
+  const FloatChatApp({super.key});
+
+  @override
+  State<FloatChatApp> createState() => _FloatChatAppState();
+}
+
+class _FloatChatAppState extends State<FloatChatApp> {
+  int _currentIndex = 1; // Chat is the initial page
+  ThemeMode _themeMode = ThemeMode.light;
+  final ValueNotifier<ProfileMode> _profileNotifier =
+      ValueNotifier<ProfileMode>(ProfileMode.general);
+
+  @override
+  void dispose() {
+    _profileNotifier.dispose();
+    super.dispose();
+  }
+
+  void _onThemeChanged(bool isDark) {
+    setState(() {
+      _themeMode = isDark ? ThemeMode.dark : ThemeMode.light;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<ProfileMode>(
+      valueListenable: _profileNotifier,
+      builder: (context, profileMode, _) {
+        return MaterialApp(
+          title: 'FloatChat',
+          debugShowCheckedModeBanner: false,
+          themeMode: _themeMode,
+          theme: ThemeData(
+            colorSchemeSeed: const Color(0xFF0A8BD9),
+            brightness: Brightness.light,
+            textTheme: GoogleFonts.interTextTheme(),
+            useMaterial3: true,
+          ),
+          darkTheme: ThemeData(
+            colorSchemeSeed: const Color(0xFF0A8BD9),
+            brightness: Brightness.dark,
+            textTheme: GoogleFonts.interTextTheme(ThemeData.dark().textTheme),
+            useMaterial3: true,
+          ),
+          home: Scaffold(
+            appBar: FloatChatAppBar(
+              profileMode: profileMode,
+              onTap: () => showProfileSelector(context, _profileNotifier),
+            ),
+            body: IndexedStack(
+              index: _currentIndex,
+              children: [
+                AnalysisPage(profileNotifier: _profileNotifier),
+                ChatPage(profileNotifier: _profileNotifier),
+                SettingsPage(
+                  onThemeChanged: _onThemeChanged,
+                  isDarkMode: _themeMode == ThemeMode.dark,
+                ),
+              ],
+            ),
+            bottomNavigationBar: NavigationBar(
+              selectedIndex: _currentIndex,
+              onDestinationSelected: (index) {
+                setState(() => _currentIndex = index);
+              },
+              destinations: const [
+                NavigationDestination(
+                  icon: Icon(Icons.public),
+                  label: 'Analysis',
+                ),
+                NavigationDestination(
+                  icon: Icon(Icons.chat_bubble_outline),
+                  label: 'Chat',
+                ),
+                NavigationDestination(
+                  icon: Icon(Icons.settings_outlined),
+                  label: 'Settings',
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class FloatChatAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const FloatChatAppBar({
+    super.key,
+    required this.profileMode,
+    required this.onTap,
+  });
+
+  final ProfileMode profileMode;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      titleSpacing: 0,
+      title: Row(
+        children: [
+          const SizedBox(width: 16),
+          CircleAvatar(
+            radius: 18,
+            backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+            child: const Text('🐬', style: TextStyle(fontSize: 20)),
+          ),
+          const SizedBox(width: 12),
+          Text(
+            'FloatChat',
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+        ],
+      ),
+      actions: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: ProfileSelectorChip(
+            profileMode: profileMode,
+            onPressed: onTap,
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/pages/analysis_page.dart
+++ b/lib/pages/analysis_page.dart
@@ -1,0 +1,1046 @@
+import 'dart:math' as math;
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../widgets/profile_selector.dart';
+
+enum FloatStatus { stable, watch, alert }
+
+extension FloatStatusX on FloatStatus {
+  String get label {
+    switch (this) {
+      case FloatStatus.stable:
+        return 'Stable';
+      case FloatStatus.watch:
+        return 'Watch';
+      case FloatStatus.alert:
+        return 'Alert';
+    }
+  }
+
+  Color get color {
+    switch (this) {
+      case FloatStatus.stable:
+        return const Color(0xFF1ABC9C);
+      case FloatStatus.watch:
+        return const Color(0xFFF39C12);
+      case FloatStatus.alert:
+        return const Color(0xFFE74C3C);
+    }
+  }
+
+  IconData get icon {
+    switch (this) {
+      case FloatStatus.stable:
+        return Icons.check_circle_outline;
+      case FloatStatus.watch:
+        return Icons.warning_amber_rounded;
+      case FloatStatus.alert:
+        return Icons.priority_high_rounded;
+    }
+  }
+}
+
+class FloatMarkerData {
+  const FloatMarkerData({
+    required this.id,
+    required this.position,
+    required this.latestTemperature,
+    required this.depthHighlight,
+    required this.salinity,
+    required this.oxygen,
+    required this.status,
+    required this.temperatureProfile,
+    required this.salinityProfile,
+    required this.oxygenSeries,
+    required this.lastUpdated,
+  });
+
+  final String id;
+  final LatLng position;
+  final double latestTemperature;
+  final double depthHighlight;
+  final double salinity;
+  final double oxygen;
+  final FloatStatus status;
+  final List<FlSpot> temperatureProfile;
+  final List<FlSpot> salinityProfile;
+  final List<FlSpot> oxygenSeries;
+  final DateTime lastUpdated;
+}
+
+class AnalysisPage extends StatefulWidget {
+  const AnalysisPage({super.key, this.profileNotifier});
+
+  final ValueNotifier<ProfileMode>? profileNotifier;
+
+  @override
+  State<AnalysisPage> createState() => _AnalysisPageState();
+}
+
+class _AnalysisPageState extends State<AnalysisPage> {
+  final MapController _mapController = MapController();
+  late final List<FloatMarkerData> _markers = _buildMarkers();
+  FloatMarkerData? _selectedMarker;
+
+  List<FloatMarkerData> _buildMarkers() {
+    return [
+      _createMarker(
+        id: 'IN-9023',
+        position: const LatLng(15.5, 73.8),
+        temperature: 28.4,
+        depth: 120,
+        salinity: 34.8,
+        oxygen: 5.6,
+        status: FloatStatus.watch,
+        hoursAgo: 2,
+      ),
+      _createMarker(
+        id: 'IN-1775',
+        position: const LatLng(9.9, 76.2),
+        temperature: 27.1,
+        depth: 140,
+        salinity: 35.2,
+        oxygen: 6.1,
+        status: FloatStatus.stable,
+        hoursAgo: 4,
+      ),
+      _createMarker(
+        id: 'IN-4410',
+        position: const LatLng(18.1, 72.9),
+        temperature: 29.2,
+        depth: 95,
+        salinity: 34.5,
+        oxygen: 5.2,
+        status: FloatStatus.alert,
+        hoursAgo: 1,
+      ),
+    ];
+  }
+
+  FloatMarkerData _createMarker({
+    required String id,
+    required LatLng position,
+    required double temperature,
+    required double depth,
+    required double salinity,
+    required double oxygen,
+    required FloatStatus status,
+    required int hoursAgo,
+  }) {
+    final profileVariation = (id.hashCode % 5) * 0.08;
+    final depthSeries = List<FlSpot>.generate(7, (index) {
+      final level = index * 320.0;
+      final base = temperature - index * 0.95;
+      final adjustment = status == FloatStatus.alert
+          ? 0.6
+          : status == FloatStatus.watch
+              ? 0.3
+              : 0.1;
+      return FlSpot(level, base - adjustment - profileVariation);
+    });
+
+    final salinitySeries = List<FlSpot>.generate(7, (index) {
+      final level = index * 320.0;
+      final base = salinity - index * 0.12;
+      final adjust = status == FloatStatus.alert
+          ? -0.25
+          : status == FloatStatus.watch
+              ? -0.1
+              : 0.05;
+      return FlSpot(level, base + adjust);
+    });
+
+    final oxygenSeries = List<FlSpot>.generate(8, (index) {
+      final day = index.toDouble();
+      final base = oxygen - math.sin(index / 6 * math.pi) * 0.25;
+      final adjust = status == FloatStatus.alert
+          ? -0.3
+          : status == FloatStatus.watch
+              ? -0.1
+              : 0.0;
+      return FlSpot(day, base + adjust);
+    });
+
+    return FloatMarkerData(
+      id: id,
+      position: position,
+      latestTemperature: temperature,
+      depthHighlight: depth,
+      salinity: salinity,
+      oxygen: oxygen,
+      status: status,
+      temperatureProfile: depthSeries,
+      salinityProfile: salinitySeries,
+      oxygenSeries: oxygenSeries,
+      lastUpdated: DateTime.now().subtract(Duration(hours: hoursAgo)),
+    );
+  }
+
+  String _timeAgo(DateTime timestamp) {
+    final difference = DateTime.now().difference(timestamp);
+    if (difference.inMinutes < 60) {
+      return '${difference.inMinutes} min ago';
+    }
+    if (difference.inHours < 24) {
+      return '${difference.inHours} h ago';
+    }
+    return '${difference.inDays} d ago';
+  }
+
+  void _openFloatDetails(FloatMarkerData data) {
+    final profileMode = widget.profileNotifier?.value ?? ProfileMode.general;
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) {
+        return DraggableScrollableSheet(
+          expand: false,
+          builder: (context, controller) {
+            return SingleChildScrollView(
+              controller: controller,
+              padding: const EdgeInsets.fromLTRB(24, 0, 24, 32),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      CircleAvatar(
+                        radius: 24,
+                        child: const Text('🐬', style: TextStyle(fontSize: 28)),
+                      ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Float ${data.id}',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .titleLarge
+                                  ?.copyWith(fontWeight: FontWeight.bold),
+                            ),
+                            Text(
+                              'Last profile: ${data.latestTemperature.toStringAsFixed(1)}°C at ${data.depthHighlight.toStringAsFixed(0)} m',
+                            ),
+                          ],
+                        ),
+                      ),
+                      Chip(
+                        avatar: Icon(data.status.icon, color: Colors.white, size: 18),
+                        label: Text(data.status.label,
+                            style: const TextStyle(color: Colors.white)),
+                        backgroundColor: data.status.color,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    'Updated ${_timeAgo(data.lastUpdated)} • ${profileMode.label}',
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(color: Theme.of(context).colorScheme.outline),
+                  ),
+                  const SizedBox(height: 20),
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    children: [
+                      _MetricCard(
+                        title: 'Temperature',
+                        value: '${data.latestTemperature.toStringAsFixed(1)} °C',
+                        subtitle: 'Surface anomaly +0.8°C',
+                        icon: Icons.thermostat,
+                      ),
+                      _MetricCard(
+                        title: 'Salinity',
+                        value: '${data.salinity.toStringAsFixed(1)} PSU',
+                        subtitle: 'Halocline shift 12 m',
+                        icon: Icons.water_drop_outlined,
+                      ),
+                      _MetricCard(
+                        title: 'Oxygen',
+                        value: '${data.oxygen.toStringAsFixed(1)} ml/l',
+                        subtitle: 'Hypoxia risk low',
+                        icon: Icons.bubble_chart_outlined,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  _InsightBanner(profileMode: profileMode, data: data),
+                  const SizedBox(height: 24),
+                  _ProfileChartsSection(data: data),
+                  const SizedBox(height: 24),
+                  const _ProfilesDescription(),
+                  const SizedBox(height: 24),
+                  _DownloadRow(floatId: data.id),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        FlutterMap(
+          mapController: _mapController,
+          options: MapOptions(
+            initialCenter: const LatLng(15.0, 78.0),
+            initialZoom: 4.8,
+            interactionOptions: const InteractionOptions(
+              flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
+            ),
+            onTap: (_, __) {
+              setState(() => _selectedMarker = null);
+            },
+          ),
+          children: [
+            TileLayer(
+              urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+              subdomains: const ['a', 'b', 'c'],
+              userAgentPackageName: 'com.example.floatchat',
+            ),
+            MarkerLayer(
+              markers: _markers
+                  .map(
+                    (marker) => Marker(
+                      point: marker.position,
+                      width: 90,
+                      height: 90,
+                      child: GestureDetector(
+                        onTap: () {
+                          setState(() => _selectedMarker = marker);
+                          _openFloatDetails(marker);
+                        },
+                        child: _MapMarker(status: marker.status, label: marker.id),
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+        ),
+        Positioned(
+          right: 16,
+          top: 16,
+          child: ElevatedButton.icon(
+            onPressed: () {
+              showModalBottomSheet(
+                context: context,
+                showDragHandle: true,
+                builder: (_) => Padding(
+                  padding: const EdgeInsets.all(24),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: const [
+                      Text(
+                        'Export queued',
+                        style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                      ),
+                      SizedBox(height: 12),
+                      Text(
+                        'A CSV export with the latest temperature, salinity, and oxygen profiles will be available in your downloads shortly. 🐬',
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+            icon: const Icon(Icons.download_outlined),
+            label: const Text('Export CSV'),
+            style: ElevatedButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+            ),
+          ),
+        ),
+        if (_selectedMarker != null)
+          Positioned(
+            left: 16,
+            right: 16,
+            bottom: 24,
+            child: _MarkerInsightCard(
+              marker: _selectedMarker!,
+              onViewDetails: () => _openFloatDetails(_selectedMarker!),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _MetricCard extends StatelessWidget {
+  const _MetricCard({
+    required this.title,
+    required this.value,
+    required this.subtitle,
+    required this.icon,
+  });
+
+  final String title;
+  final String value;
+  final String subtitle;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: 170,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.6),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, color: theme.colorScheme.primary),
+          const SizedBox(height: 12),
+          Text(title, style: theme.textTheme.titleSmall),
+          const SizedBox(height: 8),
+          Text(
+            value,
+            style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 6),
+          Text(subtitle, style: theme.textTheme.bodySmall),
+        ],
+      ),
+    );
+  }
+}
+
+class _InsightBanner extends StatelessWidget {
+  const _InsightBanner({required this.profileMode, required this.data});
+
+  final ProfileMode profileMode;
+  final FloatMarkerData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final statusTone = switch (data.status) {
+      FloatStatus.stable =>
+          'Stable column with resilient oxygen (${data.oxygen.toStringAsFixed(1)} ml/l) and minimal salinity drift.',
+      FloatStatus.watch =>
+          'Watchlist: surface warmed to ${data.latestTemperature.toStringAsFixed(1)}°C and halocline lifted ${data.depthHighlight.toStringAsFixed(0)} m.',
+      FloatStatus.alert =>
+          'Alert: sharp ${data.latestTemperature.toStringAsFixed(1)}°C spike with oxygen dipping near ${data.oxygen.toStringAsFixed(1)} ml/l. Escalate review.',
+    };
+
+    final personaTone = switch (profileMode) {
+      ProfileMode.agency =>
+          'Recommend issuing a policy brief for coastal stakeholders and adjusting EEZ advisories.',
+      ProfileMode.researcher =>
+          'Queue comparative casts and align with upcoming monsoon campaigns for deeper context.',
+      ProfileMode.educator =>
+          'Use this float to show students how heat and salinity shift after a storm pulse.',
+      ProfileMode.general =>
+          'Great moment to follow Della’s insight trail and see the ocean breathe in real-time.',
+    };
+
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('🐬', style: TextStyle(fontSize: 28)),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  statusTone,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color:
+                            Theme.of(context).colorScheme.onPrimaryContainer,
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  personaTone,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodySmall
+                      ?.copyWith(
+                        color:
+                            Theme.of(context).colorScheme.onPrimaryContainer,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileChartsSection extends StatelessWidget {
+  const _ProfileChartsSection({required this.data});
+
+  final FloatMarkerData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Profiles in dashboard',
+          style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 12),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            _InsightPill(
+              icon: Icons.thermostat,
+              color: scheme.primary,
+              text: 'Surface ${data.latestTemperature.toStringAsFixed(1)}°C',
+            ),
+            _InsightPill(
+              icon: Icons.water_drop_outlined,
+              color: scheme.secondary,
+              text: 'Salinity ${data.salinity.toStringAsFixed(1)} PSU',
+            ),
+            _InsightPill(
+              icon: Icons.bubble_chart,
+              color: scheme.tertiary,
+              text: 'Oxygen ${data.oxygen.toStringAsFixed(1)} ml/l',
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        _ChartCard(
+          title: 'Temperature profile',
+          subtitle: 'Depth vs °C across latest cast',
+          child: LineChart(_depthChartData(
+            context,
+            spots: data.temperatureProfile,
+            color: Colors.orangeAccent,
+            unitSuffix: '°C',
+          )),
+        ),
+        const SizedBox(height: 20),
+        _ChartCard(
+          title: 'Salinity structure',
+          subtitle: 'Halocline shift compared to climatology',
+          child: LineChart(_depthChartData(
+            context,
+            spots: data.salinityProfile,
+            color: scheme.primary,
+            unitSuffix: 'PSU',
+          )),
+        ),
+        const SizedBox(height: 20),
+        _ChartCard(
+          title: 'Oxygen trend (7 days)',
+          subtitle: 'Daily mean ml/l measurements',
+          child: LineChart(_oxygenChartData(context, data.oxygenSeries, scheme)),
+        ),
+      ],
+    );
+  }
+
+  LineChartData _depthChartData(
+    BuildContext context, {
+    required List<FlSpot> spots,
+    required Color color,
+    required String unitSuffix,
+  }) {
+    final minY = spots.map((e) => e.y).reduce(math.min) - 0.4;
+    final maxY = spots.map((e) => e.y).reduce(math.max) + 0.4;
+    final interval = _interval(minY, maxY);
+
+    return LineChartData(
+      minX: 0,
+      maxX: 2000,
+      minY: minY,
+      maxY: maxY,
+      lineTouchData: const LineTouchData(enabled: false),
+      gridData: FlGridData(
+        show: true,
+        horizontalInterval: interval,
+        verticalInterval: 500,
+        getDrawingHorizontalLine: (value) => FlLine(
+          color: Theme.of(context).colorScheme.outlineVariant.withOpacity(0.25),
+          strokeWidth: 1,
+        ),
+        getDrawingVerticalLine: (value) => FlLine(
+          color: Theme.of(context).colorScheme.outlineVariant.withOpacity(0.25),
+          strokeWidth: 1,
+        ),
+      ),
+      titlesData: FlTitlesData(
+        topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        bottomTitles: AxisTitles(
+          axisNameWidget: const Padding(
+            padding: EdgeInsets.only(top: 4),
+            child: Text('Depth (m)', style: TextStyle(fontSize: 11)),
+          ),
+          sideTitles: SideTitles(
+            showTitles: true,
+            interval: 500,
+            reservedSize: 44,
+            getTitlesWidget: (value, meta) {
+              if (value % 500 != 0) return const SizedBox.shrink();
+              return Text('${value.toInt()}',
+                  style: const TextStyle(fontSize: 10));
+            },
+          ),
+        ),
+        leftTitles: AxisTitles(
+          axisNameWidget: Padding(
+            padding: const EdgeInsets.only(right: 6),
+            child: Text(unitSuffix, style: const TextStyle(fontSize: 11)),
+          ),
+          sideTitles: SideTitles(
+            showTitles: true,
+            interval: interval,
+            reservedSize: 48,
+            getTitlesWidget: (value, meta) => Text(
+              value.toStringAsFixed(1),
+              style: const TextStyle(fontSize: 10),
+            ),
+          ),
+        ),
+      ),
+      borderData: FlBorderData(
+        show: true,
+        border: Border.all(
+          color: Theme.of(context).colorScheme.outlineVariant.withOpacity(0.4),
+        ),
+      ),
+      lineBarsData: [
+        LineChartBarData(
+          spots: spots,
+          color: color,
+          barWidth: 3,
+          isCurved: true,
+          dotData: const FlDotData(show: false),
+        ),
+      ],
+    );
+  }
+
+  LineChartData _oxygenChartData(
+    BuildContext context,
+    List<FlSpot> spots,
+    ColorScheme scheme,
+  ) {
+    final minY = spots.map((e) => e.y).reduce(math.min) - 0.2;
+    final maxY = spots.map((e) => e.y).reduce(math.max) + 0.2;
+    final interval = _interval(minY, maxY);
+    final maxX = spots.map((e) => e.x).reduce(math.max);
+
+    return LineChartData(
+      minX: 0,
+      maxX: maxX,
+      minY: minY,
+      maxY: maxY,
+      lineTouchData: const LineTouchData(enabled: false),
+      gridData: FlGridData(
+        show: true,
+        horizontalInterval: interval,
+        verticalInterval: 1,
+        getDrawingHorizontalLine: (value) => FlLine(
+          color: scheme.outlineVariant.withOpacity(0.25),
+          strokeWidth: 1,
+        ),
+        getDrawingVerticalLine: (value) => FlLine(
+          color: scheme.outlineVariant.withOpacity(0.2),
+          strokeWidth: 1,
+        ),
+      ),
+      titlesData: FlTitlesData(
+        topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        bottomTitles: AxisTitles(
+          axisNameWidget: const Padding(
+            padding: EdgeInsets.only(top: 4),
+            child: Text('Day', style: TextStyle(fontSize: 11)),
+          ),
+          sideTitles: SideTitles(
+            showTitles: true,
+            interval: 1,
+            getTitlesWidget: (value, meta) => Text(
+              'D${value.toInt() + 1}',
+              style: const TextStyle(fontSize: 10),
+            ),
+          ),
+        ),
+        leftTitles: AxisTitles(
+          axisNameWidget: const Padding(
+            padding: EdgeInsets.only(right: 6),
+            child: Text('ml/l', style: TextStyle(fontSize: 11)),
+          ),
+          sideTitles: SideTitles(
+            showTitles: true,
+            interval: interval,
+            reservedSize: 46,
+            getTitlesWidget: (value, meta) => Text(
+              value.toStringAsFixed(2),
+              style: const TextStyle(fontSize: 10),
+            ),
+          ),
+        ),
+      ),
+      borderData: FlBorderData(
+        show: true,
+        border: Border.all(
+          color: scheme.outlineVariant.withOpacity(0.4),
+        ),
+      ),
+      lineBarsData: [
+        LineChartBarData(
+          spots: spots,
+          color: scheme.primary,
+          barWidth: 3,
+          isCurved: true,
+          dotData: const FlDotData(show: true),
+        ),
+      ],
+    );
+  }
+
+  double _interval(double min, double max) {
+    final range = max - min;
+    if (range <= 0) {
+      return 1;
+    }
+    final interval = range / 4;
+    return (interval.clamp(0.2, 3.0)) as double;
+  }
+}
+
+class _ChartCard extends StatelessWidget {
+  const _ChartCard({
+    required this.title,
+    required this.subtitle,
+    required this.child,
+  });
+
+  final String title;
+  final String subtitle;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.45),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            subtitle,
+            style: theme.textTheme.bodySmall,
+          ),
+          const SizedBox(height: 12),
+          SizedBox(height: 200, child: child),
+        ],
+      ),
+    );
+  }
+}
+
+class _InsightPill extends StatelessWidget {
+  const _InsightPill({
+    required this.icon,
+    required this.text,
+    required this.color,
+  });
+
+  final IconData icon;
+  final String text;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: color.withOpacity(0.3)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: 6),
+          Text(text, style: TextStyle(color: color, fontWeight: FontWeight.w600)),
+        ],
+      ),
+    );
+  }
+}
+
+class _MapMarker extends StatelessWidget {
+  const _MapMarker({required this.status, required this.label});
+
+  final FloatStatus status;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: status.color,
+            shape: BoxShape.circle,
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.18),
+                blurRadius: 12,
+                offset: const Offset(0, 6),
+              ),
+            ],
+          ),
+          child: Icon(status.icon, color: Colors.white, size: 24),
+        ),
+        const SizedBox(height: 6),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: Colors.black.withOpacity(0.65),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Text(
+            label,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MarkerInsightCard extends StatelessWidget {
+  const _MarkerInsightCard({
+    required this.marker,
+    required this.onViewDetails,
+  });
+
+  final FloatMarkerData marker;
+  final VoidCallback onViewDetails;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Material(
+      elevation: 12,
+      borderRadius: BorderRadius.circular(24),
+      color: scheme.surface.withOpacity(0.95),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                CircleAvatar(
+                  radius: 26,
+                  backgroundColor: marker.status.color,
+                  child: Icon(marker.status.icon, color: Colors.white, size: 26),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Float ${marker.id}',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Text(
+                        'Surface ${marker.latestTemperature.toStringAsFixed(1)}°C • O₂ ${marker.oxygen.toStringAsFixed(1)} ml/l',
+                        style: theme.textTheme.bodySmall,
+                      ),
+                    ],
+                  ),
+                ),
+                FilledButton.tonalIcon(
+                  onPressed: onViewDetails,
+                  icon: const Icon(Icons.insights),
+                  label: const Text('View profile'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              height: 90,
+              child: LineChart(
+                LineChartData(
+                  minX: 0,
+                  maxX: marker.oxygenSeries.map((e) => e.x).reduce(math.max),
+                  minY: marker.oxygenSeries.map((e) => e.y).reduce(math.min) - 0.2,
+                  maxY: marker.oxygenSeries.map((e) => e.y).reduce(math.max) + 0.2,
+                  lineTouchData: const LineTouchData(enabled: false),
+                  gridData: const FlGridData(show: false),
+                  titlesData: FlTitlesData(
+                    topTitles:
+                        const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                    rightTitles:
+                        const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                    bottomTitles: const AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                    leftTitles: const AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                  ),
+                  borderData: FlBorderData(
+                    show: true,
+                    border: Border.all(
+                      color: scheme.outlineVariant.withOpacity(0.4),
+                    ),
+                  ),
+                  lineBarsData: [
+                    LineChartBarData(
+                      spots: marker.oxygenSeries,
+                      color: marker.status.color,
+                      barWidth: 3,
+                      isCurved: true,
+                      dotData: const FlDotData(show: false),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              marker.status == FloatStatus.alert
+                  ? 'Della flagged a sharp thermocline compression and oxygen dip. Consider exporting full NetCDF for audit.'
+                  : marker.status == FloatStatus.watch
+                      ? 'Warm anomaly persists; overlay cyclone tracks or compare with last month to anticipate shifts.'
+                      : 'Conditions stable with healthy oxygenation. Perfect baseline for comparison.',
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ProfilesDescription extends StatelessWidget {
+  const _ProfilesDescription();
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Profile Plots',
+          style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          'Y-axis: Depth (0–2000 m). X-axis: Temperature / Salinity / Oxygen etc. Shows how the ocean changes with depth.',
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Time Series of Profiles',
+          style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          'Profiles collected over time → compare January vs June at the same location.',
+        ),
+        const SizedBox(height: 12),
+        Text(
+          'Profile Map Integration',
+          style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          'Each float’s location on map → click → see its latest profile. Profiles = the core data product of ARGO.',
+        ),
+        const SizedBox(height: 12),
+        const Text(
+          'Use the dashboard to select a float, view the latest profile, overlay multiple profiles (e.g., before & after a cyclone), download in CSV/NetCDF, and spot anomalies like “surface warming > 1°C compared to baseline.”',
+        ),
+      ],
+    );
+  }
+}
+
+class _DownloadRow extends StatelessWidget {
+  const _DownloadRow({required this.floatId});
+
+  final String floatId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ElevatedButton.icon(
+          onPressed: () {},
+          icon: const Icon(Icons.stacked_line_chart),
+          label: const Text('Overlay profiles'),
+        ),
+        const SizedBox(height: 12),
+        ElevatedButton.icon(
+          onPressed: () {},
+          icon: const Icon(Icons.analytics_outlined),
+          label: Text('View anomalies for $floatId'),
+        ),
+        const SizedBox(height: 12),
+        OutlinedButton.icon(
+          onPressed: () {},
+          icon: const Icon(Icons.download_for_offline_outlined),
+          label: const Text('Download NetCDF'),
+        ),
+      ],
+    );
+  }
+}
+

--- a/lib/pages/chat_page.dart
+++ b/lib/pages/chat_page.dart
@@ -1,0 +1,528 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../widgets/profile_selector.dart';
+
+class ChatMessage {
+  ChatMessage({
+    required this.text,
+    required this.isUser,
+    this.insight,
+  });
+
+  final String text;
+  final bool isUser;
+  final ChatInsightData? insight;
+}
+
+class ChatInsightData {
+  ChatInsightData({
+    required this.temperatureProfile,
+    required this.salinityProfile,
+    required this.oxygenSeries,
+  });
+
+  final List<FlSpot> temperatureProfile;
+  final List<FlSpot> salinityProfile;
+  final List<FlSpot> oxygenSeries;
+}
+
+class ChatPage extends StatefulWidget {
+  const ChatPage({super.key, this.profileNotifier});
+
+  final ValueNotifier<ProfileMode>? profileNotifier;
+
+  @override
+  State<ChatPage> createState() => _ChatPageState();
+}
+
+class _ChatPageState extends State<ChatPage> {
+  final TextEditingController _controller = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  final List<ChatMessage> _messages = [
+    ChatMessage(
+      text:
+          '🐬 Hello! I\'m Della the FloatChat dolphin. Ask me about any ARGO float and I\'ll surface insights with maps, graphs, and context.',
+      isUser: false,
+    ),
+  ];
+  bool _isGenerating = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _sendMessage() {
+    final trimmed = _controller.text.trim();
+    if (trimmed.isEmpty || _isGenerating) return;
+
+    setState(() {
+      _messages.add(ChatMessage(text: trimmed, isUser: true));
+      _isGenerating = true;
+      _controller.clear();
+    });
+
+    _scrollToBottom();
+
+    final profile = widget.profileNotifier?.value ?? ProfileMode.general;
+    Timer(const Duration(milliseconds: 1800), () {
+      if (!mounted) return;
+      final insight = _buildInsightData(profile, trimmed);
+      setState(() {
+        _messages.add(ChatMessage(
+          isUser: false,
+          text: _mockResponse(profile, trimmed),
+          insight: insight,
+        ));
+        _isGenerating = false;
+      });
+      _scrollToBottom();
+    });
+  }
+
+  String _mockResponse(ProfileMode profile, String query) {
+    final baseIntro = switch (profile) {
+      ProfileMode.agency =>
+          'For policy review: wave height anomalies near Bay of Bengal show +1.2m versus baseline.',
+      ProfileMode.researcher =>
+          'Research brief: Float 290313 analyzed. Thermocline dipped 35m post-monsoon burst.',
+      ProfileMode.educator =>
+          'Classroom snapshot: notice how warm surface water layers mix during summer monsoon.',
+      ProfileMode.general =>
+          'Ocean insight: surface temps are trending warmer around the Indian peninsula.',
+    };
+
+    return '$baseIntro\n\nBased on your prompt "$query", I\'ve staged depth vs temperature and salinity charts plus an oxygen anomaly timeline below. Tap the Analysis tab to compare floats, overlay cyclonic events, or export NetCDF snapshots. 🐬';
+  }
+
+  ChatInsightData _buildInsightData(ProfileMode profile, String query) {
+    final hash = query.hashCode.abs();
+    final double tempOffset = ((hash % 7) - 3) * 0.12;
+    final double salinityOffset = (((hash >> 3) % 5) - 2) * 0.05;
+    final double oxygenOffset = (((hash >> 6) % 5) - 2) * 0.07;
+    final double profileAdjustment = profile.index * 0.15;
+
+    final temperatureProfile = List<FlSpot>.generate(7, (index) {
+      final depth = index * 320.0;
+      final base = 29.2 - index * 0.95 - profileAdjustment;
+      return FlSpot(depth, base - tempOffset);
+    });
+
+    final salinityProfile = List<FlSpot>.generate(7, (index) {
+      final depth = index * 320.0;
+      final base = 35.1 - index * 0.14 + salinityOffset;
+      return FlSpot(depth, base);
+    });
+
+    final oxygenSeries = List<FlSpot>.generate(8, (index) {
+      final day = index.toDouble();
+      final base = 5.3 + math.sin((index / 7) * math.pi) * 0.35;
+      return FlSpot(day, base + oxygenOffset);
+    });
+
+    return ChatInsightData(
+      temperatureProfile: temperatureProfile,
+      salinityProfile: salinityProfile,
+      oxygenSeries: oxygenSeries,
+    );
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_scrollController.hasClients) return;
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent + 80,
+        duration: const Duration(milliseconds: 350),
+        curve: Curves.easeOut,
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.separated(
+            controller: _scrollController,
+            padding: const EdgeInsets.all(20),
+            itemCount: _messages.length + (_isGenerating ? 1 : 0),
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemBuilder: (context, index) {
+              if (_isGenerating && index == _messages.length) {
+                return Align(
+                  alignment: Alignment.centerLeft,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceVariant.withOpacity(0.6),
+                      borderRadius: BorderRadius.circular(18),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: const [
+                        SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2.5),
+                        ),
+                        SizedBox(width: 12),
+                        Text('Della is crafting insights...'),
+                      ],
+                    ),
+                  ),
+                );
+              }
+
+              final message = _messages[index];
+              final alignment =
+                  message.isUser ? Alignment.centerRight : Alignment.centerLeft;
+              final bubbleColor = message.isUser
+                  ? theme.colorScheme.primaryContainer
+                  : theme.colorScheme.surfaceVariant.withOpacity(0.6);
+              final textColor = message.isUser
+                  ? theme.colorScheme.onPrimaryContainer
+                  : theme.colorScheme.onSurfaceVariant;
+              final bubbleMaxWidth =
+                  MediaQuery.of(context).size.width * (message.isUser ? 0.7 : 0.9);
+              final insight = message.insight;
+              return Align(
+                alignment: alignment,
+                child: Container(
+                  constraints: BoxConstraints(maxWidth: bubbleMaxWidth),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+                  decoration: BoxDecoration(
+                    color: bubbleColor,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: message.isUser
+                        ? CrossAxisAlignment.end
+                        : CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        message.text,
+                        style: theme.textTheme.bodyMedium
+                            ?.copyWith(color: textColor),
+                      ),
+                      if (!message.isUser && insight != null) ...[
+                        const SizedBox(height: 12),
+                        _buildInsightCharts(insight, theme),
+                      ],
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        SafeArea(
+          top: false,
+          minimum: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+          child: _buildInputBar(context),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildInputBar(BuildContext context) {
+    final theme = Theme.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(28),
+        color: theme.colorScheme.surfaceVariant.withOpacity(0.4),
+      ),
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.add_circle_outline),
+            tooltip: 'Upload files for analysis',
+            onPressed: () {
+              showModalBottomSheet(
+                context: context,
+                showDragHandle: true,
+                builder: (context) {
+                  return Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: const [
+                        Text(
+                          'Upload Data',
+                          style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                        ),
+                        SizedBox(height: 12),
+                        Text(
+                          'Attach NetCDF, CSV, or imagery files to enrich the upcoming analysis. The preview and parsing will appear in chat. 🐬',
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+          Expanded(
+            child: TextField(
+              controller: _controller,
+              minLines: 1,
+              maxLines: 4,
+              decoration: const InputDecoration(
+                hintText: 'Ask Della to explore ARGO floats, trends, or anomalies...',
+                border: InputBorder.none,
+              ),
+              onSubmitted: (_) => _sendMessage(),
+            ),
+          ),
+          const SizedBox(width: 4),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: FilledButton.tonal(
+              onPressed: _isGenerating ? null : _sendMessage,
+              style: FilledButton.styleFrom(
+                shape: const CircleBorder(),
+                padding: const EdgeInsets.all(18),
+              ),
+              child: const Icon(Icons.send_rounded),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInsightCharts(ChatInsightData insight, ThemeData theme) {
+    final scheme = theme.colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildDepthProfileChart(
+          title: 'Temperature vs depth',
+          spots: insight.temperatureProfile,
+          color: Colors.orangeAccent,
+          unitSuffix: '°C',
+          theme: theme,
+        ),
+        const SizedBox(height: 14),
+        _buildDepthProfileChart(
+          title: 'Salinity vs depth',
+          spots: insight.salinityProfile,
+          color: scheme.primary,
+          unitSuffix: 'PSU',
+          theme: theme,
+        ),
+        const SizedBox(height: 14),
+        Text(
+          'Oxygen trend (7 days)',
+          style: theme.textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+            color: scheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 6),
+        SizedBox(
+          height: 170,
+          child: LineChart(_oxygenSeriesData(insight.oxygenSeries, theme)),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDepthProfileChart({
+    required String title,
+    required List<FlSpot> spots,
+    required Color color,
+    required String unitSuffix,
+    required ThemeData theme,
+  }) {
+    final minY = spots.map((e) => e.y).reduce(math.min) - 0.4;
+    final maxY = spots.map((e) => e.y).reduce(math.max) + 0.4;
+    final interval = _axisInterval(minY, maxY);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: theme.textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w600,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 6),
+        SizedBox(
+          height: 180,
+          child: LineChart(
+            LineChartData(
+              minX: 0,
+              maxX: 2000,
+              minY: minY,
+              maxY: maxY,
+              lineTouchData: const LineTouchData(enabled: false),
+              gridData: FlGridData(
+                show: true,
+                horizontalInterval: interval,
+                verticalInterval: 500,
+                getDrawingHorizontalLine: (value) => FlLine(
+                  color: theme.colorScheme.outlineVariant.withOpacity(0.25),
+                  strokeWidth: 1,
+                ),
+                getDrawingVerticalLine: (value) => FlLine(
+                  color: theme.colorScheme.outlineVariant.withOpacity(0.25),
+                  strokeWidth: 1,
+                ),
+              ),
+              titlesData: FlTitlesData(
+                topTitles:
+                    const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                rightTitles:
+                    const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+                bottomTitles: AxisTitles(
+                  axisNameWidget: const Padding(
+                    padding: EdgeInsets.only(top: 4),
+                    child: Text('Depth (m)', style: TextStyle(fontSize: 11)),
+                  ),
+                  sideTitles: SideTitles(
+                    showTitles: true,
+                    interval: 500,
+                    reservedSize: 44,
+                    getTitlesWidget: (value, meta) {
+                      if (value % 500 != 0) return const SizedBox.shrink();
+                      return Text('${value.toInt()}',
+                          style: const TextStyle(fontSize: 10));
+                    },
+                  ),
+                ),
+                leftTitles: AxisTitles(
+                  axisNameWidget: Padding(
+                    padding: const EdgeInsets.only(right: 6),
+                    child: Text(unitSuffix,
+                        style: const TextStyle(fontSize: 11)),
+                  ),
+                  sideTitles: SideTitles(
+                    showTitles: true,
+                    interval: interval,
+                    reservedSize: 46,
+                    getTitlesWidget: (value, meta) => Text(
+                      value.toStringAsFixed(1),
+                      style: const TextStyle(fontSize: 10),
+                    ),
+                  ),
+                ),
+              ),
+              borderData: FlBorderData(
+                show: true,
+                border: Border.all(
+                  color: theme.colorScheme.outlineVariant.withOpacity(0.4),
+                ),
+              ),
+              lineBarsData: [
+                LineChartBarData(
+                  spots: spots,
+                  color: color,
+                  barWidth: 3,
+                  isCurved: true,
+                  dotData: const FlDotData(show: false),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  LineChartData _oxygenSeriesData(List<FlSpot> spots, ThemeData theme) {
+    final minY = spots.map((e) => e.y).reduce(math.min) - 0.2;
+    final maxY = spots.map((e) => e.y).reduce(math.max) + 0.2;
+    final maxX = spots.map((e) => e.x).reduce(math.max);
+    final interval = _axisInterval(minY, maxY);
+
+    return LineChartData(
+      minX: 0,
+      maxX: maxX,
+      minY: minY,
+      maxY: maxY,
+      lineTouchData: const LineTouchData(enabled: false),
+      gridData: FlGridData(
+        show: true,
+        horizontalInterval: interval,
+        verticalInterval: 1,
+        getDrawingHorizontalLine: (value) => FlLine(
+          color: theme.colorScheme.outlineVariant.withOpacity(0.25),
+          strokeWidth: 1,
+        ),
+        getDrawingVerticalLine: (value) => FlLine(
+          color: theme.colorScheme.outlineVariant.withOpacity(0.2),
+          strokeWidth: 1,
+        ),
+      ),
+      titlesData: FlTitlesData(
+        topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        leftTitles: AxisTitles(
+          axisNameWidget: const Padding(
+            padding: EdgeInsets.only(right: 6),
+            child: Text('ml/l', style: TextStyle(fontSize: 11)),
+          ),
+          sideTitles: SideTitles(
+            showTitles: true,
+            interval: interval,
+            reservedSize: 42,
+            getTitlesWidget: (value, meta) => Text(
+              value.toStringAsFixed(2),
+              style: const TextStyle(fontSize: 10),
+            ),
+          ),
+        ),
+        bottomTitles: AxisTitles(
+          axisNameWidget: const Padding(
+            padding: EdgeInsets.only(top: 4),
+            child: Text('Day', style: TextStyle(fontSize: 11)),
+          ),
+          sideTitles: SideTitles(
+            showTitles: true,
+            interval: 1,
+            getTitlesWidget: (value, meta) => Text(
+              'D${value.toInt() + 1}',
+              style: const TextStyle(fontSize: 10),
+            ),
+          ),
+        ),
+      ),
+      borderData: FlBorderData(
+        show: true,
+        border: Border.all(
+          color: theme.colorScheme.outlineVariant.withOpacity(0.4),
+        ),
+      ),
+      lineBarsData: [
+        LineChartBarData(
+          spots: spots,
+          color: theme.colorScheme.primary,
+          barWidth: 3,
+          isCurved: true,
+          dotData: const FlDotData(show: true),
+        ),
+      ],
+    );
+  }
+
+  double _axisInterval(double min, double max) {
+    final range = max - min;
+    if (range <= 0) {
+      return 1;
+    }
+    final interval = range / 4;
+    return (interval.clamp(0.2, 3.0)) as double;
+  }
+}

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key, this.onThemeChanged, this.isDarkMode = false});
+
+  final ValueChanged<bool>? onThemeChanged;
+  final bool isDarkMode;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(20),
+      children: [
+        _SettingsSection(
+          title: 'Preferences',
+          children: [
+            SwitchListTile(
+              title: const Text('Dark theme'),
+              subtitle: const Text('Toggle to rest your eyes during late-night dives.'),
+              value: isDarkMode,
+              onChanged: onThemeChanged,
+              secondary: const Icon(Icons.nightlight_round),
+            ),
+            SwitchListTile(
+              title: const Text('Enable notifications'),
+              subtitle: const Text('Get pinged when Della detects new anomalies.'),
+              value: true,
+              onChanged: (_) {},
+              secondary: const Icon(Icons.notifications_active_outlined),
+            ),
+            SwitchListTile(
+              title: const Text('Ocean health digests'),
+              subtitle: const Text('Weekly digest of top floats and regions to watch.'),
+              value: true,
+              onChanged: (_) {},
+              secondary: const Icon(Icons.podcasts_outlined),
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        _SettingsSection(
+          title: 'Storage & privacy',
+          children: [
+            ListTile(
+              leading: const Icon(Icons.cleaning_services_outlined),
+              title: const Text('Clear cache'),
+              subtitle: const Text('Remove downloaded ARGO profiles and previews.'),
+              trailing: FilledButton(
+                onPressed: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Cache cleared. Della thanks you! 🐬')),
+                  );
+                },
+                child: const Text('Clear'),
+              ),
+            ),
+            ListTile(
+              leading: const Icon(Icons.lock_outline),
+              title: const Text('Privacy controls'),
+              subtitle: const Text('Manage how shared data contributes to community insights.'),
+              onTap: () {},
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        _SettingsSection(
+          title: 'Account',
+          children: [
+            ListTile(
+              leading: const Icon(Icons.person_outline),
+              title: const Text('Profile & identity'),
+              subtitle: const Text('Adjust your ocean role, avatar, and affiliations.'),
+              onTap: () {},
+            ),
+            ListTile(
+              leading: const Icon(Icons.logout),
+              title: const Text('Logout'),
+              subtitle: const Text('Surface for air and sign back in later.'),
+              onTap: () {},
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _SettingsSection extends StatelessWidget {
+  const _SettingsSection({required this.title, required this.children});
+
+  final String title;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 12),
+        ...children.map(
+          (child) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceVariant.withOpacity(0.35),
+                borderRadius: BorderRadius.circular(18),
+              ),
+              child: child,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/profile_selector.dart
+++ b/lib/widgets/profile_selector.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+
+enum ProfileMode {
+  agency,
+  researcher,
+  educator,
+  general,
+}
+
+extension ProfileModeX on ProfileMode {
+  String get label {
+    switch (this) {
+      case ProfileMode.agency:
+        return 'Agency Mode';
+      case ProfileMode.researcher:
+        return 'Researcher Mode';
+      case ProfileMode.educator:
+        return 'Educator Mode';
+      case ProfileMode.general:
+        return 'General Model';
+    }
+  }
+
+  String get description {
+    switch (this) {
+      case ProfileMode.agency:
+        return 'Policy-ready intelligence for agencies & policymakers.';
+      case ProfileMode.researcher:
+        return 'Data-deep dives with scientific context for researchers.';
+      case ProfileMode.educator:
+        return 'Classroom-friendly explanations for educators & students.';
+      case ProfileMode.general:
+        return 'Conversational ocean insights for everyone.';
+    }
+  }
+
+  IconData get icon {
+    switch (this) {
+      case ProfileMode.agency:
+        return Icons.account_balance;
+      case ProfileMode.researcher:
+        return Icons.science_outlined;
+      case ProfileMode.educator:
+        return Icons.menu_book_outlined;
+      case ProfileMode.general:
+        return Icons.emoji_people_outlined;
+    }
+  }
+}
+
+class ProfileSelectorChip extends StatelessWidget {
+  const ProfileSelectorChip({
+    super.key,
+    required this.profileMode,
+    required this.onPressed,
+  });
+
+  final ProfileMode profileMode;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return InkWell(
+      onTap: onPressed,
+      borderRadius: BorderRadius.circular(30),
+      child: Ink(
+        decoration: BoxDecoration(
+          color: colorScheme.surfaceVariant.withOpacity(0.45),
+          borderRadius: BorderRadius.circular(30),
+          border: Border.all(color: colorScheme.outlineVariant, width: 1.2),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              profileMode.icon,
+              size: 20,
+              color: colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: 8),
+            Text(
+              profileMode.label,
+              style: Theme.of(context)
+                  .textTheme
+                  .labelLarge
+                  ?.copyWith(color: colorScheme.onSurfaceVariant),
+            ),
+            const SizedBox(width: 6),
+            Icon(
+              Icons.keyboard_arrow_down,
+              size: 18,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> showProfileSelector(
+  BuildContext context,
+  ValueNotifier<ProfileMode> profileNotifier,
+) async {
+  final theme = Theme.of(context);
+  await showModalBottomSheet(
+    context: context,
+    showDragHandle: true,
+    builder: (context) {
+      return ValueListenableBuilder<ProfileMode>(
+        valueListenable: profileNotifier,
+        builder: (context, selectedMode, _) {
+          return ListView.separated(
+            padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
+            itemCount: ProfileMode.values.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
+            itemBuilder: (context, index) {
+              final mode = ProfileMode.values[index];
+              final isSelected = mode == selectedMode;
+              return ListTile(
+                leading: CircleAvatar(
+                  child: Icon(mode.icon),
+                ),
+                title: Text(mode.label, style: theme.textTheme.titleMedium),
+                subtitle: Text(mode.description),
+                trailing: isSelected
+                    ? Icon(Icons.check_circle, color: theme.colorScheme.primary)
+                    : null,
+                onTap: () {
+                  profileNotifier.value = mode;
+                  Navigator.of(context).pop();
+                },
+              );
+            },
+          );
+        },
+      );
+    },
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,21 @@
+name: floatchat
+description: A prototype AI-assisted ocean analysis chat application.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  flutter_map: ^6.0.0
+  latlong2: ^0.9.1
+  google_fonts: ^6.1.0
+  fl_chart: ^0.66.2
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/


### PR DESCRIPTION
## Summary
- restyle the app bar profile selector and remove the redundant chat input mode switch while injecting charted AI responses with mock data
- upgrade the analysis map with color-coded status markers, a selectable insight card, chart-rich float detail sheets, and reliable OpenStreetMap tiles
- add the fl_chart dependency to share chart widgets across chat and analysis experiences

## Testing
- Not run (Flutter SDK unavailable in environment)

------
https://chatgpt.com/codex/tasks/task_e_68d199069d488332a11b357f59fc48d3